### PR TITLE
Add support for python virtualenv configuration

### DIFF
--- a/macros/zah.autoclip.lua
+++ b/macros/zah.autoclip.lua
@@ -169,7 +169,7 @@ local c = function(command_input)
         return "powershell -Command \"" .. command .. "\""
     else
         if config["enable_python_virtual_env_activate"] then
-            command = exe_fmt("python_virtual_env_activate")
+            command = "source " .. exe_fmt("python_virtual_env_activate")
         end
 
         for chunks in re_newline:gsplit(command_input, true) do

--- a/macros/zah.autoclip.lua
+++ b/macros/zah.autoclip.lua
@@ -153,9 +153,7 @@ local c = function(command_input)
     local command = ""
     if jit.os == "Windows" then
         if config["enable_python_virtual_env_activate"] then
-            -- Not sure if anyone's PC lacks permissions to run the python virtualenv powershell script
-            -- command = "$LASTEXITCODE=0; Set-ExecutionPolicy -Scope Process -ExecutionPolicy Unrestricted -Force; & " .. exe_fmt("python_virtual_env_activate")
-            command = "$LASTEXITCODE=0; & " .. exe_fmt("python_virtual_env_activate")
+            command = "$LASTEXITCODE=0; Set-ExecutionPolicy -Scope Process -ExecutionPolicy Unrestricted -Force; & " .. exe_fmt("python_virtual_env_activate")
         end
 
         for chunks in re_newline:gsplit(command_input, true) do


### PR DESCRIPTION
Add a checkbox to set up the activate script of the python virtual environment.
As long as it is checked, the Python path input box should fill in the activate script path. (`<virtualenv python dir>\Scripts\activate.ps1` for Windows or `<virtualenv python dir>/Scripts/activate` for Linux)
In this case, the program will execute the activate script first and then call the python command.

![configuation](https://github.com/Zahuczky/Zahuczkys-Aegisub-Scripts/assets/4166753/bab4a376-fd54-4f82-ae3c-c65d0b8ee6f0)
