### PR TITLE
Only add transforms on frames when color/alpha changes

### DIFF
--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -33,14 +33,14 @@
 			"fileBaseUrl": "@{fileBaseUrl}/@{channel}/macros/aegi-color-track/@{namespace}",
 			"channels": {
 				"main": {
-					"version": "2.1.0",
-					"released": "2024-06-16",
+					"version": "2.2.0",
+					"released": "2024-06-21",
 					"default": true,
 					"files": [
 						{
 							"name": ".lua",
 							"url": "@{fileBaseUrl}@{fileName}",
-							"sha1": "95642136f70f3086f5dcbe2a50eb014800962736"
+							"sha1": "170d2c211daf796fa020c5e91b4b0f4f0c154b29"
 						}
 					],
 					"requiredModules": [
@@ -67,7 +67,7 @@
 					"Various fixes by Petzku"
 				],
 				"2.0.0": [
-					"Complete restrocture by garret, no more png dissecting, support for new API version in arch1 builds."
+					"Complete restructure by garret, no more png dissecting, support for new API version in arch1 builds."
 				],
 				"2.0.1": [
 					"Adding progress reporting"
@@ -78,6 +78,9 @@
 				],
 				"2.1.0": [
 					"Add alpha tracking mode"
+				],
+				"2.2.0": [
+					"Only insert transforms on frames where the color/alpha changes"
 				]
 			}
 		},

--- a/macros/aegi-color-track/zah.aegi-color-track.lua
+++ b/macros/aegi-color-track/zah.aegi-color-track.lua
@@ -348,26 +348,31 @@ function colortrack(subtitles, selected_lines, active_line)
   local transform = ""
   -- stylua: ignore start
   if MODE == "Color" then
+    local last_color = nil
     if colors[1] then
       if res.c then transform = transform.."\\c"..colors[1] end
       if res.c2 then transform = transform.."\\2c"..colors[1] end
       if res.c3 then transform = transform.."\\3c"..colors[1] end
       if res.c4 then transform = transform.."\\4c"..colors[1] end
+      last_color = colors[1]
     end
     for i=2, numOfFrames do
       local color = colors[i]
       -- color could be nil if the tracking point is outside video frame
-      if color then
-      transform = transform.."\\t("..makeTransformTimes(i-1)
+      -- don't add redundant transform if color is the same as last frame
+      if color and color ~= last_color then
+        transform = transform.."\\t("..makeTransformTimes(i-1)
         if res.c then transform = transform.."\\c"..color end
         if res.c2 then transform = transform.."\\2c"..color end
         if res.c3 then transform = transform.."\\3c"..color end
         if res.c4 then transform = transform.."\\4c"..color end
-      transform = transform .. ")"
+        transform = transform .. ")"
+        last_color = color
       end
     end
   end
   if MODE == "Alpha" then
+    local last_alpha = nil
     if res.all then
       res.a = false
       res.a2 = false
@@ -376,6 +381,7 @@ function colortrack(subtitles, selected_lines, active_line)
     end
     if colors[1] then
       alpha = calculateAlpha(res.startc, res.endc, assToHtmlColor(colors[1]))
+      last_alpha = alpha
       if res.all then transform = transform.."\\alpha&H"..alpha.."&" end
       if res.a then transform = transform.."\\1a&H"..alpha.."&" end
       if res.a2 then transform = transform.."\\2a&H"..alpha.."&" end
@@ -385,15 +391,19 @@ function colortrack(subtitles, selected_lines, active_line)
     for i=2, numOfFrames do
       local color = colors[i]
       -- color could be nil if the tracking point is outside video frame
+      -- don't add redundant transform if alpha is the same as last frame
       if color then
         alpha = calculateAlpha(res.startc, res.endc, assToHtmlColor(color))
-        transform = transform.."\\t("..makeTransformTimes(i-1)
-        if res.all then transform = transform.."\\alpha&H"..alpha.."&" end
-        if res.a then transform = transform.."\\1a&H"..alpha.."&" end
-        if res.a2 then transform = transform.."\\2a&H"..alpha.."&" end
-        if res.a3 then transform = transform.."\\3a&H"..alpha.."&" end
-        if res.a4 then transform = transform.."\\4a&H"..alpha.."&" end
-      transform = transform .. ")"
+        if alpha ~= last_alpha then
+          transform = transform.."\\t("..makeTransformTimes(i-1)
+          if res.all then transform = transform.."\\alpha&H"..alpha.."&" end
+          if res.a then transform = transform.."\\1a&H"..alpha.."&" end
+          if res.a2 then transform = transform.."\\2a&H"..alpha.."&" end
+          if res.a3 then transform = transform.."\\3a&H"..alpha.."&" end
+          if res.a4 then transform = transform.."\\4a&H"..alpha.."&" end
+          last_alpha = alpha
+          transform = transform .. ")"
+        end
       end
     end
   end


### PR DESCRIPTION
Skip redundant transforms where the color/alpha is the same as the previous frame.

Only having transforms for changes makes the line much shorter, but ASSWipe can't detect the redundant transforms, so it needs to be implemented in this macro instead.
