### PR TITLE
color-track: Parse x,y pair in tracking data as single point

### DIFF
--- a/macros/aegi-color-track/zah.aegi-color-track.lua
+++ b/macros/aegi-color-track/zah.aegi-color-track.lua
@@ -308,8 +308,16 @@ function colortrack(subtitles, selected_lines, active_line)
       p = p + 1
     end
   elseif res.setting == "Defined pixels" then
-    XPixels = res.pixX
-    YPixels = res.pixY
+    -- if a single set of coordinates is present in the textbox, use it
+    local xCoord, yCoord = res.data:match "^%s*(%d*%.?%d*),(%d*%.?%d*)%s*$"
+
+    if xCoord and yCoord then
+      XPixels = math.floor(xCoord+0.5)
+      YPixels = math.floor(yCoord+0.5)
+    else
+      XPixels = res.pixX
+      YPixels = res.pixY
+    end
   end
 
   -- if res.setting == "Middle of Rect. Clip" then


### PR DESCRIPTION
Inputting coordinates to the color tracker is awkward if you use the "Copy coordinates to Clipboard" action because the X and Y coordinates are separate input boxes. 

This solution parses a single pair of x,y coordinates from the data input field and rounds them to the nearest int. This functionality is only enabled in the `Defined pixels` mode, not `Tracking Data`.

Because the data is parsed after the GUI is closed, it doesn't save the coordinates in the persistent GUI config.

An alternative solution I thought of was adding a "parse from clipboard" button that would parse the clipboard contents for an x,y pair and insert them into the coordinate input fields. However, I thought it would be more flexible and user-friendly to parse from the text field instead.